### PR TITLE
Update GroundOverlay.php

### DIFF
--- a/overlays/GroundOverlay.php
+++ b/overlays/GroundOverlay.php
@@ -39,9 +39,9 @@ class GroundOverlay extends CircleOptions
     public function init()
     {
 
-        if ($this->url == null || $this->getBounds() == null) {
-            throw new InvalidConfigException('"url" and/or "bounds" cannot be null');
-        }
+        //if ($this->url == null || $this->getBounds() == null) {
+            //throw new InvalidConfigException('"url" and/or "bounds" cannot be null');
+        //}
     }
 
 


### PR DESCRIPTION
Init method runs at end of constructor.
So, as soon as we set 
```php
$bounds = new LatLngBounds();
```

It throws error, need to disable init check.
Maybe we can find some other way?