### PR TITLE
Fix 'latlng' param

### DIFF
--- a/services/GeocodingClient.php
+++ b/services/GeocodingClient.php
@@ -87,7 +87,7 @@ class GeocodingClient extends ClientAbstract
      */
     public function reverse(LatLng $coord, $params = [])
     {
-        $params['latlng'] = $coord;
+        $params['latlng'] = $coord->__toString();
 
         $this->params = ArrayHelper::merge($this->params, $params);
 


### PR DESCRIPTION
LatLng param wasn't converted to string before request. This causes 'Bad request' error
