### PR TITLE
Update for PHP 7.2

### DIFF
--- a/ClientAbstract.php
+++ b/ClientAbstract.php
@@ -8,7 +8,7 @@ namespace dosamigos\google\maps;
 
 use Exception;
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Client as HttpClient;
 
@@ -22,7 +22,7 @@ use GuzzleHttp\Client as HttpClient;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-abstract class ClientAbstract extends Object
+abstract class ClientAbstract extends BaseObject
 {
     /**
      * @var string response format. Can be json or xml.
@@ -98,4 +98,4 @@ abstract class ClientAbstract extends Object
         }
         return $this->_guzzle;
     }
-} 
+}

--- a/Event.php
+++ b/Event.php
@@ -8,7 +8,7 @@ namespace dosamigos\google\maps;
 
 use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Event
@@ -20,7 +20,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-class Event extends Object
+class Event extends BaseObject
 {
     /**
      * @var string the action that will trigger the event
@@ -138,4 +138,4 @@ class Event extends Object
                 return $this->getEventJs($name);
         }
     }
-} 
+}

--- a/LatLngBounds.php
+++ b/LatLngBounds.php
@@ -10,7 +10,7 @@ namespace dosamigos\google\maps;
 use dosamigos\google\maps\overlays\Marker;
 use dosamigos\google\maps\overlays\Polygon;
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -23,7 +23,7 @@ use yii\helpers\ArrayHelper;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-class LatLngBounds extends Object
+class LatLngBounds extends BaseObject
 {
     /**
      * @var LatLng|null South West coordinate
@@ -419,4 +419,4 @@ class LatLngBounds extends Object
             'northEast' => new LatLng(['lat' => $neLat, 'lng' => $neLng])
         ]);
     }
-} 
+}

--- a/ObjectAbstract.php
+++ b/ObjectAbstract.php
@@ -7,7 +7,7 @@
 namespace dosamigos\google\maps;
 
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
 use yii\helpers\Json;
@@ -24,7 +24,7 @@ use yii\base\InvalidParamException;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-abstract class ObjectAbstract extends Object
+abstract class ObjectAbstract extends BaseObject
 {
     /**
      * @var integer a counter used to generate [[id]] for map objects.
@@ -37,7 +37,7 @@ abstract class ObjectAbstract extends Object
      */
     public static $autoNamePrefix = 'g';
     /**
-     * @var array the client options of the object. Objects will be initialized with default options.
+     * @var array the client options of the object. BaseObjects will be initialized with default options.
      */
     public $options = [];
     /**
@@ -210,4 +210,4 @@ abstract class ObjectAbstract extends Object
             parent::__unset($name);
         }
     }
-} 
+}

--- a/ObjectAbstract.php
+++ b/ObjectAbstract.php
@@ -37,7 +37,7 @@ abstract class ObjectAbstract extends BaseObject
      */
     public static $autoNamePrefix = 'g';
     /**
-     * @var array the client options of the object. BaseObjects will be initialized with default options.
+     * @var array the client options of the object. Objects will be initialized with default options.
      */
     public $options = [];
     /**

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -7,7 +7,7 @@
 namespace dosamigos\google\maps;
 
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -20,7 +20,7 @@ use yii\helpers\ArrayHelper;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-class PluginManager extends Object
+class PluginManager extends BaseObject
 {
     /**
      * @var array stores the managed plugins
@@ -97,4 +97,4 @@ class PluginManager extends Object
     {
         return isset($this->_plugins[$name]) ? $this->_plugins[$name] : null;
     }
-} 
+}

--- a/Point.php
+++ b/Point.php
@@ -7,7 +7,7 @@
 namespace dosamigos\google\maps;
 
 use yii\base\InvalidConfigException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Point
@@ -19,7 +19,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-class Point extends Object
+class Point extends BaseObject
 {
     /**
      *
@@ -97,4 +97,4 @@ class Point extends Object
     {
         return "new google.maps.Point({$this->_x}, {$this->_y})";
     }
-} 
+}

--- a/Size.php
+++ b/Size.php
@@ -7,7 +7,7 @@
 namespace dosamigos\google\maps;
 
 use yii\base\InvalidConfigException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Size
@@ -19,7 +19,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\google\maps
  */
-class Size extends Object
+class Size extends BaseObject
 {
     /**
      *
@@ -93,4 +93,4 @@ class Size extends Object
     {
         return "new google.maps.Size({$this->_width}, {$this->_height})";
     }
-} 
+}


### PR DESCRIPTION
This PR is to fix https://github.com/2amigos/yii2-google-maps-library/issues/94.
http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.object-reserved-word
https://github.com/yiisoft/yii2/blob/master/framework/UPGRADE.md#upgrade-from-yii-2012