### PR TITLE
Added setIcon() and setRepeat() methods to render direction icons on the Polyline

### DIFF
--- a/overlays/IconSequence.php
+++ b/overlays/IconSequence.php
@@ -53,6 +53,26 @@ class IconSequence extends ObjectAbstract
     }
 
     /**
+     * Sets the distance between consecutive icons on the line.
+     *
+     * @param string $repeat
+     */
+    public function setRepeat($repeat)
+    {
+        $this->options['repeat'] = $repeat;
+    }
+
+    /**
+     * Sets the icon Symbol to render on the line
+     * 
+     * @param Symbol $icon
+     */
+    public function setIcon(Symbol $icon)
+    {
+        $this->options['icon'] = $icon;
+    }
+
+    /**
      * Sets the path of the [IconSequence]
      *
      * @param $value

--- a/overlays/PolylineOptions.php
+++ b/overlays/PolylineOptions.php
@@ -103,10 +103,10 @@ class PolylineOptions extends ObjectAbstract
      *
      * @param LatLng[] $coords
      */
-    public function setPath($coords)
+/*    public function setPath($coords)
     {
         foreach ($coords as $coord) {
             $this->addCoord($coord);
         }
-    }
+    }*/
 } 


### PR DESCRIPTION
Dear friend,
I faced a problem with displaying direction arrows on the polyline overlay.
Itried it this way:

```
$lineSymbolPath = new SymbolPath();
$lineSymbol = new Symbol([
    'strokeColor' => '#F00',
    'fillColor' => '#F00',
    'path' => $lineSymbolPath::FORWARD_CLOSED_ARROW,
    'fillOpacity' => 1,
    'strokeOpacity' => 1,
    'scale' => 2
]);
$coords = getCoords($model);

$iconSequence = new IconSequence([
    **'icon'** => $lineSymbol,
    **'repeat'** => '100px'
]);

$polylineOptions = new PolylineOptions([
    'strokeColor' => '#F00',
    'strokeWeight' => 2,
    'icons' => [$iconSequence],
    'path' => $coords
]);

$polyline = new Polyline($polylineOptions);
```

... and received a message
`Setting unknown property: dosamigos\google\maps\overlays\IconSequence::icon`

I fixed this issue by adding related setters to the `IconSequence` class.
Thanks for your attention to my request.