### PR TITLE
Cast width and height attributes of Map to integer explicitly [PHP 7.2 fix]

### DIFF
--- a/Map.php
+++ b/Map.php
@@ -201,7 +201,7 @@ class Map extends ObjectAbstract
         $markers = $this->getMarkers();
         $bounds = LatLngBounds::getBoundsOfMarkers($markers, $margin);
 
-        return $bounds->getZoom(min($this->width, $this->height), $default);
+        return $bounds->getZoom(min((int) $this->width, (int) $this->height), $default);
 
     }
 
@@ -247,7 +247,7 @@ class Map extends ObjectAbstract
      */
     public function getBoundsFromCenterAndZoom()
     {
-        return LatLngBounds::getBoundsFromCenterAndZoom($this->center, $this->zoom, $this->width, $this->height);
+        return LatLngBounds::getBoundsFromCenterAndZoom($this->center, $this->zoom, (int) $this->width, (int) $this->height);
     }
 
     /**


### PR DESCRIPTION
Casting them both to integer prevents:
`PHP Notice:  A non well formed numeric value encountered in php`
Which happens when on PHP 7.2

I know this is a quick fix and not the best solution but if you do not like it, I will be happy to dig into it more a come up with a better solution. 