### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "ext-SimpleXML": "^7.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.10@dev",
-        "roave/security-advisories": "dev-master"
+        "friendsofphp/php-cs-fixer": "^2.10@dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It is not a good idea to require this extension in a third party project. Each takes care of itself.

Please make a new release.